### PR TITLE
Added a makefile to build a shared library

### DIFF
--- a/joycon-core/Makefile
+++ b/joycon-core/Makefile
@@ -1,0 +1,11 @@
+CC = g++ -std=c++14
+FLAGS = -march=native -Wall -g -rdynamic
+LIBS	= -I/usr/local/include -L/usr/local/lib -lhidapi-hidraw -pthread
+
+A_SRC = joycon-core.cpp
+A_TARGET = libjoycon-core.so
+
+.PHONY: libjoycon-core.so
+joycon-core.so: $(A_SRC)
+	$(CC) $(A_SRC) $(FLAGS) $(LIBS) -shared -fPIC -o $(A_TARGET)
+		@echo "> Compiled joycon-core.so"


### PR DESCRIPTION
The makefile builds a shared library in the root source folder to ease usage. Might as well add an install procedure to make it system-wide available.